### PR TITLE
resize-helper: fixing part number and checking for table type

### DIFF
--- a/resize-helper
+++ b/resize-helper
@@ -36,14 +36,17 @@ RESIZE2FS=$(which resize2fs) || { echo "E: You must have resize2fs" && exit 1; }
 ROOT_DEVICE=$(findmnt --noheadings --output=SOURCE / | cut -d'[' -f1)
 # prune root device (for example UUID)
 ROOT_DEVICE=$(realpath ${ROOT_DEVICE})
-# get the partition number
-PARTITION=$(udevadm info --query=property --name=${ROOT_DEVICE} | grep '^PARTN=' | cut -d'=' -f2)
+# get the partition number and type
+PART_NUMBER=$(udevadm info --query=property --name=${ROOT_DEVICE} | grep '^ID_PART_ENTRY_NUMBER=' | cut -d'=' -f2)
+PART_TABLE_TYPE=$(udevadm info --query=property --name=${ROOT_DEVICE} | grep '^ID_PART_TABLE_TYPE=' | cut -d'=' -f2)
 # find the block device
 DEVICE=$(udevadm info --query=path --name=${ROOT_DEVICE} | awk -F'/' '{print $(NF-1)}')
 DEVICE="/dev/${DEVICE}"
 
-${SGDISK} -e ${DEVICE}
-${PARTPROBE}
-${PARTED} ${DEVICE} resizepart ${PARTITION} Yes 100%
+if [ "$PART_TABLE_TYPE" = "gpt" ]; then
+	${SGDISK} -e ${DEVICE}
+	${PARTPROBE}
+fi
+${PARTED} ${DEVICE} resizepart ${PART_NUMBER} Yes 100%
 ${PARTPROBE}
 ${RESIZE2FS} "${ROOT_DEVICE}"


### PR DESCRIPTION
Current udevadm info output shows the part number as part of the ID_PART_ENTRY_NUMBER variable. This was causing parted to be called without the right partition number.

Also checking for table type, and avoid calling sgdisk when it is mbr (e.g. sd card).

Not yet properly tested, doing pull-request to get early feedback. Sdcard is still not resized during first boot, but it works fine if you call the changed script by hand.