### PR TITLE
resize-helper: Remove 'Yes' from parted cmdline

### DIFF
--- a/resize-helper
+++ b/resize-helper
@@ -48,6 +48,6 @@ if [ "$PART_TABLE_TYPE" = "gpt" ]; then
 	${PARTPROBE}
 fi
 
-${PARTED} ${DEVICE} resizepart ${PART_ENTRY_NUMBER} Yes 100%
+${PARTED} ${DEVICE} resizepart ${PART_ENTRY_NUMBER} 100%
 ${PARTPROBE}
 ${RESIZE2FS} "${ROOT_DEVICE}"


### PR DESCRIPTION
This is not a valid option with latest parted
We get

/usr/sbin/parted /dev/mmcblk0 resizepart 2 Yes 100%
Error: Invalid number.

and the resizing fails.

Removing 'Yes' get the command work properly and
resize succeeds.

Tested on rpi3

Signed-off-by: Khem Raj <raj.khem@gmail.com>