### PR TITLE
Revert "resize-helper.service: Use ConditionFirstBoot directive"

### DIFF
--- a/resize-helper.service
+++ b/resize-helper.service
@@ -1,11 +1,11 @@
 [Unit]
 Description=Resize root filesystem to fit available disk space
 After=systemd-remount-fs.service
-ConditionFirstBoot=yes
 
 [Service]
 Type=oneshot
 ExecStart=-/usr/sbin/resize-helper
+ExecStartPost=/bin/systemctl disable resize-helper.service
 
 [Install]
 WantedBy=basic.target


### PR DESCRIPTION
This reverts commit 906d4bde05b1e2d276deebecd789b53675fd7922.

The systemd recipe creates an empty /etc/machine-id file, as such the FirstBoot
condition is never triggered, and the resize-helper script never gets executed.

Signed-off-by: Nicolas Dechesne <nicolas.dechesne@linaro.org>