### PR TITLE
resize-disk: Remove call to reboot

### DIFF
--- a/resize-disk
+++ b/resize-disk
@@ -3,6 +3,5 @@ if [ ! -e /var/lib/misc/firstrun ]; then
         /usr/sbin/resize-helper
         mkdir -p /var/lib/misc
         touch /var/lib/misc/firstrun
-        /sbin/reboot
 fi
 


### PR DESCRIPTION
We do not require explicit reboot, since its resizing very early on boot.
this helps automation and test which can get confused by such forced reboots

Signed-off-by: Khem Raj <raj.khem@gmail.com>