### PR TITLE
resize-helper.service: wait for udevadm settle before using udevadm info

### DIFF
--- a/resize-helper.service
+++ b/resize-helper.service
@@ -1,9 +1,11 @@
 [Unit]
 Description=Resize root filesystem to fit available disk space
-After=systemd-remount-fs.service
+Wants=systemd-udevd.service systemd-udev-trigger.service
+After=systemd-remount-fs.service systemd-udevd.service
 
 [Service]
 Type=oneshot
+ExecStartPre=-/bin/udevadm settle
 ExecStart=-/usr/sbin/resize-helper
 ExecStartPost=/bin/systemctl disable resize-helper.service
 


### PR DESCRIPTION
Otherwise the ID_* variables will not be available in time for
resize-helper.

This will make the job run later in the boot process, but it is the only way to have a reliable output out of udevadm info (otherwise the ID_* variables will not be populated in time for the script).

This fixes the resize for some of the boards I tested this script with, such as beaglebone (sdcard).