### PR TITLE
resize-helper: fix resize without partition table

### DIFF
--- a/resize-helper
+++ b/resize-helper
@@ -38,6 +38,13 @@ ROOT_DEVICE=$(findmnt --noheadings --output=SOURCE / | cut -d'[' -f1)
 ROOT_DEVICE=$(realpath ${ROOT_DEVICE})
 # get the partition number and type
 PART_ENTRY_NUMBER=$(udevadm info --query=property --name=${ROOT_DEVICE} | grep '^ID_PART_ENTRY_NUMBER=' | cut -d'=' -f2)
+
+# in case the root device is not on a partitioned media
+if [ "x$PART_ENTRY_NUMBER" = "x" ]; then
+	${RESIZE2FS} "${ROOT_DEVICE}"
+	exit 0
+fi
+
 PART_TABLE_TYPE=$(udevadm info --query=property --name=${ROOT_DEVICE} | grep '^ID_PART_TABLE_TYPE=' | cut -d'=' -f2)
 # find the block device
 DEVICE=$(udevadm info --query=path --name=${ROOT_DEVICE} | awk -F'/' '{print $(NF-1)}')


### PR DESCRIPTION
If you boot the ext4 image directly, ROOT_DEVICE is /dev/vda,
and there is no partition number. Skip adjusting the partition
table since there isn't one.

Signed-off-by: Riku Voipio <riku.voipio@linaro.org>