### PR TITLE
resize-helper: allow resizing rootfs even if already mounted

### DIFF
--- a/resize-helper
+++ b/resize-helper
@@ -55,6 +55,8 @@ if [ "$PART_TABLE_TYPE" = "gpt" ]; then
 	${PARTPROBE}
 fi
 
-${PARTED} ${DEVICE} resizepart ${PART_ENTRY_NUMBER} 100%
+# 'Yes' is required when partition is already mounted
+${PARTED} -s ${DEVICE} resizepart ${PART_ENTRY_NUMBER} 100% || \
+	${PARTED} ---pretend-input-tty ${DEVICE} resizepart ${PART_ENTRY_NUMBER} Yes 100%
 ${PARTPROBE}
 ${RESIZE2FS} "${ROOT_DEVICE}"


### PR DESCRIPTION
Parted fails to resize the rootfs if it is already mounted by the
system, so replicate the parted command with an additional syntax to
force resize if the first call failed (two commands are required as the
syntax are not compatible with each other).

Signed-off-by: Ricardo Salveti <ricardo@opensourcefoundries.com>