### PR TITLE
resize-helper: Make parted non-interactive for resizepart

### DIFF
--- a/resize-helper
+++ b/resize-helper
@@ -54,7 +54,6 @@ if [ "$PART_TABLE_TYPE" = "gpt" ]; then
 	${SGDISK} -e ${DEVICE}
 	${PARTPROBE}
 fi
-
-${PARTED} ${DEVICE} resizepart ${PART_ENTRY_NUMBER} 100%
+echo -e "yes\n100%" | ${PARTED} ${DEVICE} ---pretend-input-tty unit % resizepart ${PART_ENTRY_NUMBER}
 ${PARTPROBE}
 ${RESIZE2FS} "${ROOT_DEVICE}"


### PR DESCRIPTION
This has been an issue on recent versions of parted see [1] [2]

[1] https://bugs.launchpad.net/ubuntu/+source/parted/+bug/1270203
[2] https://lists.gnu.org/archive/html/bug-parted/2020-01/msg00005.html

Signed-off-by: Khem Raj <raj.khem@gmail.com>