### PR TITLE
resize-helper: Protect secondary GPT at the end of disk

### DIFF
--- a/resize-helper
+++ b/resize-helper
@@ -53,6 +53,7 @@ if [ "x$PART_ENTRY_NUMBER" = "x" ]; then
 fi
 
 if [ "$PART_TABLE_TYPE" = "gpt" ]; then
+	END_SIZE=$((DEVICE_SIZE - 34))
 	${SGDISK} -e ${DEVICE}
 	${PARTPROBE}
 fi


### PR DESCRIPTION
When GUID partition scheme is in use then
The GPT partition table is expected to be written at both the
start and end of the disk. When the disk is expanded, the second GPT table,
which is a backup copy of the partition table, is no longer located at the
physical end of the disk, which is the cause of the errors observed.

see https://en.wikipedia.org/wiki/GUID_Partition_Table

Therefore in case gpt is used then spare last 34 sectors so the backup
GPT is preserved

Fixes parted errors like
Error: Unable to satisfy all constraints on the partition.

Signed-off-by: Khem Raj <raj.khem@gmail.com>